### PR TITLE
增加h2依赖

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
             <version>2.0.0-M3</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/lingxi/lingxi_java/common/BaseEntity.java
+++ b/src/main/java/com/lingxi/lingxi_java/common/BaseEntity.java
@@ -1,7 +1,8 @@
 package com.lingxi.lingxi_java.common;
 
-import jakarta.persistence.*;
-import lombok.Data;
+import java.io.Serializable;
+import java.util.Date;
+
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -9,8 +10,13 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.io.Serializable;
-import java.util.Date;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Data;
 
 @Data
 @MappedSuperclass
@@ -18,7 +24,7 @@ import java.util.Date;
 @DynamicUpdate
 public abstract class BaseEntity implements Serializable {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @CreatedBy
     @Column(nullable = false, columnDefinition = "bigint default 0")

--- a/src/main/java/com/lingxi/lingxi_java/common/BaseEntity.java
+++ b/src/main/java/com/lingxi/lingxi_java/common/BaseEntity.java
@@ -13,7 +13,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Data;
@@ -24,7 +23,7 @@ import lombok.Data;
 @DynamicUpdate
 public abstract class BaseEntity implements Serializable {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue
     private Long id;
     @CreatedBy
     @Column(nullable = false, columnDefinition = "bigint default 0")

--- a/src/test/java/com/lingxi/lingxi_java/auth/MyRepositoryTests.java
+++ b/src/test/java/com/lingxi/lingxi_java/auth/MyRepositoryTests.java
@@ -1,0 +1,47 @@
+package com.lingxi.lingxi_java.auth;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.lingxi.lingxi_java.auth.domain.User;
+import com.lingxi.lingxi_java.auth.domain.UserRepository;
+import com.lingxi.lingxi_java.utils.EncryptUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+@ActiveProfiles("h2")
+class MyRepositoryTests {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private UserRepository repository;
+
+    @Test
+    void testExample() {
+        assertNotNull(entityManager);
+        User user = new User();
+        String username = "holyliao";
+        user.setUsername(username);
+        user.setPassword(EncryptUtil.md5(username));
+        this.entityManager.persist(user);
+        Optional<User> target = this.repository.findOneByUsername(username);
+
+        assertTrue(target.isPresent());
+        assertEquals(target.get().getUsername(), username);
+        assertEquals(target.get().getPassword(), EncryptUtil.md5(username));
+    }
+
+}

--- a/src/test/java/com/lingxi/lingxi_java/auth/MyRepositoryTests.java
+++ b/src/test/java/com/lingxi/lingxi_java/auth/MyRepositoryTests.java
@@ -5,9 +5,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.lingxi.lingxi_java.auth.domain.User;
@@ -15,28 +13,23 @@ import com.lingxi.lingxi_java.auth.domain.UserRepository;
 import com.lingxi.lingxi_java.utils.EncryptUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SpringBootTest
 @ExtendWith(SpringExtension.class)
-@DataJpaTest
-@ActiveProfiles("h2")
 class MyRepositoryTests {
-
-    @Autowired
-    private TestEntityManager entityManager;
 
     @Autowired
     private UserRepository repository;
 
     @Test
     void testExample() {
-        assertNotNull(entityManager);
         User user = new User();
         String username = "holyliao";
+
         user.setUsername(username);
         user.setPassword(EncryptUtil.md5(username));
-        this.entityManager.persist(user);
+        repository.save(user);
         Optional<User> target = this.repository.findOneByUsername(username);
 
         assertTrue(target.isPresent());

--- a/src/test/resources/application-h2.yml
+++ b/src/test/resources/application-h2.yml
@@ -26,7 +26,9 @@ spring:
     defer-datasource-initialization: true
   sql:
     init:
-      mode: NEVER
+      mode: EMBEDDED
+      platform: h2
+      data-locations:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher

--- a/src/test/resources/application-h2.yml
+++ b/src/test/resources/application-h2.yml
@@ -1,0 +1,35 @@
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: trace
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:lingxi;DB_CLOSE_DELAY=-1;CASE_INSENSITIVE_IDENTIFIERS=TRUE
+    username: sa
+    password:
+    driverClassName: org.h2.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        use_sql_comments: true
+        format_sql: true
+        auto_quote_keyword: true
+    generate-ddl: true
+    show-sql: true
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: NEVER
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+custom:
+  jwt-secret: ${JWT_SECRET:lingxi_jwt}

--- a/src/test/resources/application-h2.yml
+++ b/src/test/resources/application-h2.yml
@@ -5,17 +5,18 @@ logging:
         type:
           descriptor:
             sql: trace
+        event: trace
 
 spring:
   datasource:
-    url: jdbc:h2:mem:lingxi;DB_CLOSE_DELAY=-1;CASE_INSENSITIVE_IDENTIFIERS=TRUE
+    url: jdbc:h2:mem:lingxi;DB_CLOSE_DELAY=-1;CASE_INSENSITIVE_IDENTIFIERS=TRUE;MODE=MYSQL;;DB_CLOSE_ON_EXIT=FALSE
     username: sa
     password:
     driverClassName: org.h2.Driver
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
-    hibernate:
-      ddl-auto: create
+#    hibernate:
+#      ddl-auto: create
     properties:
       hibernate:
         use_sql_comments: true
@@ -28,7 +29,7 @@ spring:
     init:
       mode: EMBEDDED
       platform: h2
-      data-locations:
+      data-locations: data-h2.sql
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher

--- a/src/test/resources/application-h2.yml
+++ b/src/test/resources/application-h2.yml
@@ -1,12 +1,3 @@
-logging:
-  level:
-    org:
-      hibernate:
-        type:
-          descriptor:
-            sql: trace
-        event: trace
-
 spring:
   datasource:
     url: jdbc:h2:mem:lingxi;DB_CLOSE_DELAY=-1;CASE_INSENSITIVE_IDENTIFIERS=TRUE;MODE=MYSQL;;DB_CLOSE_ON_EXIT=FALSE
@@ -25,14 +16,13 @@ spring:
     generate-ddl: true
     show-sql: true
     defer-datasource-initialization: true
+    hibernate:
+      use-new-id-generator-mappings:
   sql:
     init:
       mode: EMBEDDED
       platform: h2
-      data-locations: data-h2.sql
-  mvc:
-    pathmatch:
-      matching-strategy: ant_path_matcher
-
-custom:
-  jwt-secret: ${JWT_SECRET:lingxi_jwt}
+      data-locations: classpath:data-h2.sql
+  config:
+    activate:
+      on-profile: h2

--- a/src/test/resources/application-mysql.yml
+++ b/src/test/resources/application-mysql.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: 123456
+    url: jdbc:mysql://${MYSQL_HOST:localhost}:3306/lingxi
+    type: com.mysql.cj.jdbc.MysqlDataSource
+  jpa:
+    generate-ddl: true
+    show-sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+  sql:
+    init:
+      platform: mysql
+      data-locations:
+  config:
+    activate:
+      on-profile: mysql

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,18 +5,18 @@ logging:
         type:
           descriptor:
             sql: trace
+
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    username: root
-    password: 123456
-    url: jdbc:mysql://${MYSQL_HOST:localhost}:3306/lingxi
-  jpa:
-    generate-ddl: true
-    show-sql: true
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+  profiles:
+    active: h2
 
 custom:
   jwt-secret: ${JWT_SECRET:lingxi_jwt}
+
+qiniu:
+  ak: ${QINIU_AK:lingxi}
+  sk: ${QINIU_SK:lingxi}
+  bucket: ${QINIU_SK:upload}

--- a/src/test/resources/data-h2.sql
+++ b/src/test/resources/data-h2.sql
@@ -1,2 +1,2 @@
 INSERT INTO "user" (id, created_at, created_by, updated_at, updated_by, avatar, nick_name, password, username)
-VALUES (DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, '/avatar.png', '灵希', '8b12aedc03901c59ba19a5a117e56936', 'lingxi');
+VALUES (10000, DEFAULT, DEFAULT, DEFAULT, DEFAULT, '/avatar.png', '灵希', '8b12aedc03901c59ba19a5a117e56936', 'lingxi');

--- a/src/test/resources/data-h2.sql
+++ b/src/test/resources/data-h2.sql
@@ -1,0 +1,2 @@
+INSERT INTO "user" (id, created_at, created_by, updated_at, updated_by, avatar, nick_name, password, username)
+VALUES (DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, '/avatar.png', '灵希', '8b12aedc03901c59ba19a5a117e56936', 'lingxi');


### PR DESCRIPTION
1.用于单元测试
2.抽取了测试配置，保留mysql数据库支持，增加了h2数据库
